### PR TITLE
Mintscan integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,9 +54,8 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test --release --no-default-features
+      - run: cargo test --release
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
+name = "iqhttp"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3de50f560e3ddb9abfaa1f56bd39f7941959ee93976b360b43fb5fe7293bfd3"
+dependencies = [
+ "hyper",
+ "hyper-rustls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +886,17 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "mintscan"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d340d9e91e50e25794e25b0c38942a29403ced412c96123ec0ec680593e5824"
+dependencies = [
+ "iqhttp",
+ "serde",
+ "tendermint",
 ]
 
 [[package]]
@@ -1386,6 +1409,8 @@ dependencies = [
  "futures",
  "gumdrop",
  "home",
+ "iqhttp",
+ "mintscan",
  "once_cell",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
-name        = "sagan"
-version     = "0.0.0"
-description = "Observability tool for Cosmos and other Tendermint applications"
-authors     = ["Tony Arcieri <tony@iqlusion.io>", "Shella Stephens <shella@iqlusion.io>"]
-license     = "Apache-2.0"
-repository  = "https://github.com/iqlusioninc/sagan"
-readme      = "README.md"
-edition     = "2018"
-categories  = ["cryptography::cryptocurrencies"]
-keywords    = ["cosmos", "tendermint"]
+name = "sagan"
+version = "0.0.0"
+description = """
+Observability tool for Cosmos and other Tendermint applications
+"""
+authors = [
+    "Tony Arcieri <tony@iqlusion.io>",
+    "Shella Stephens <shella@iqlusion.io>"
+]
+license    = "Apache-2.0"
+repository = "https://github.com/iqlusioninc/sagan"
+readme     = "README.md"
+edition    = "2018"
+categories = ["cryptography::cryptocurrencies"]
+keywords   = ["cosmos", "tendermint"]
 
 [dependencies]
 abscissa_core = "0.6.0-pre.1"
@@ -16,6 +21,7 @@ abscissa_tokio = "0.6.0-pre.1"
 futures = "0.3"
 gumdrop = "0.7"
 home = "0.5"
+iqhttp = { version = "0.0.1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 tendermint = "0.19"
@@ -26,9 +32,15 @@ toml = "0.5"
 tokio = "1"
 warp = "0.3"
 
+# optional dependencies
+mintscan = { version = "0.0.1", optional = true }
+
 [dev-dependencies]
 once_cell = "1"
 
 [dev-dependencies.abscissa_core]
 version = "0.6.0-pre.1"
 features = ["testing"]
+
+[features]
+default = ["mintscan"]

--- a/sagan.toml.example
+++ b/sagan.toml.example
@@ -8,5 +8,7 @@ addr = "127.0.0.1"
 port = 7322
 protocol = "http"
 
-[collector.networks]
-tendermint = ["cosmoshub-2"]
+[[collector.networks.tendermint]]
+chain_id = "cosmoshub-4"
+validator_addr = "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7"
+# mintscan = { host = "api.cosmostation.io" }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,6 +1,7 @@
 //! HTTP collector
 
+mod poller;
 mod router;
 mod state;
 
-pub use self::{router::Router, state::State};
+pub use self::{poller::Poller, router::Router, state::State};

--- a/src/collector/poller.rs
+++ b/src/collector/poller.rs
@@ -1,0 +1,88 @@
+//! Collector poller
+
+#[cfg(feature = "mintscan")]
+mod mintscan;
+
+use crate::config;
+use crate::prelude::*;
+use std::time::Duration;
+use tokio::time;
+
+#[cfg(feature = "mintscan")]
+use futures::future;
+
+/// The collector's [`Poller`] collects information from external sources
+/// which aren't capable of pushing data.
+pub struct Poller {
+    /// Interval at which to poll
+    poll_interval: Duration,
+
+    /// Mintscan API endpoints to poll
+    #[cfg(feature = "mintscan")]
+    mintscan: Vec<mintscan::Poller>,
+}
+
+impl Poller {
+    /// Initialize the poller from the config
+    #[cfg_attr(not(feature = "mintscan"), allow(unused_variables))]
+    pub fn new(config: &config::collector::Config) -> Result<Self, Error> {
+        // TODO(tarcieri): configurable poll interval
+        let poll_interval = Duration::from_secs(60);
+
+        // Initialize Mintscan if configured
+        #[cfg(feature = "mintscan")]
+        let mintscan = config
+            .networks
+            .tendermint
+            .iter()
+            .flat_map(mintscan::Poller::new)
+            .collect();
+
+        Ok(Self {
+            poll_interval,
+            #[cfg(feature = "mintscan")]
+            mintscan,
+        })
+    }
+
+    /// Route incoming requests.
+    pub async fn run(self) {
+        if !self.has_sources() {
+            info!("no sources to poll");
+            return;
+        }
+
+        info!("polling every {:?}", self.poll_interval);
+        let mut interval = time::interval(self.poll_interval);
+
+        loop {
+            interval.tick().await;
+            self.poll().await;
+            info!("waiting for {:?}", self.poll_interval);
+        }
+    }
+
+    /// Poll sources.
+    async fn poll(&self) {
+        #[cfg(feature = "mintscan")]
+        let mut futures = vec![];
+
+        #[cfg(feature = "mintscan")]
+        for mintscan_poller in &self.mintscan {
+            futures.push(mintscan_poller.poll());
+        }
+
+        #[cfg(feature = "mintscan")]
+        future::join_all(futures).await;
+    }
+
+    /// Are there any configured sources?
+    fn has_sources(&self) -> bool {
+        #[cfg(feature = "mintscan")]
+        if !self.mintscan.is_empty() {
+            return true;
+        }
+
+        false
+    }
+}

--- a/src/collector/poller/mintscan.rs
+++ b/src/collector/poller/mintscan.rs
@@ -1,0 +1,88 @@
+//! Mintscan poller
+
+use crate::{config, prelude::*};
+use mintscan::{Address, Mintscan};
+use tendermint::chain;
+
+/// Mintscan poller
+pub struct Poller {
+    /// API hostname
+    host: String,
+
+    /// Mintscan client
+    client: Mintscan,
+
+    /// Tendermint chain ID
+    chain_id: chain::Id,
+
+    /// Validator operator address (if configured)
+    validator_addr: Option<Address>,
+
+    /// Alerting threshold for missed blocks
+    missed_block_threshold: u64,
+}
+
+impl Poller {
+    /// Create a new Mintscan poller for the given Tendermint network, if it
+    /// has a Mintscan configuration.
+    pub fn new(config: &config::network::tendermint::Config) -> Option<Self> {
+        config.mintscan.as_ref().map(|mintscan_config| {
+            let host = mintscan_config.host.clone();
+            let client = Mintscan::new(&host);
+
+            // TODO(tarcieri): make this configurable
+            let missed_block_threshold = 50;
+
+            Self {
+                host,
+                client,
+                chain_id: config.chain_id.clone(),
+                validator_addr: config.validator_addr.clone(),
+                missed_block_threshold,
+            }
+        })
+    }
+
+    /// Poll Mintscan for status and validator info
+    pub async fn poll(&self) {
+        let chain_height = match self.client.status().await {
+            Ok(status) => status.block_height,
+            Err(err) => {
+                warn!("[{}] error polling {}: {}", &self.chain_id, &self.host, err);
+                return;
+            }
+        };
+
+        info!("[{}] chain height: {}", &self.chain_id, chain_height);
+
+        if let Some(addr) = &self.validator_addr {
+            let validator_height = match self.client.validator_uptime(addr).await {
+                // TODO(tarcieri): do something with `uptime.uptime` (i.e. missed blocks)?
+                Ok(uptime) => uptime.latest_height,
+                Err(err) => {
+                    warn!(
+                        "[{}] can't fetch validator uptime for {} from {}: {}",
+                        &self.chain_id, addr, &self.host, err
+                    );
+                    return;
+                }
+            };
+
+            info!(
+                "[{}] validator height for {}: {}",
+                &self.chain_id, addr, validator_height
+            );
+
+            let height_delta = chain_height
+                .value()
+                .saturating_sub(validator_height.value());
+
+            if height_delta > self.missed_block_threshold {
+                error!(
+                    "[{}] validator {} has missed {} blocks!",
+                    &self.chain_id, addr, height_delta
+                );
+            }
+        }
+    }
+}

--- a/src/collector/router.rs
+++ b/src/collector/router.rs
@@ -1,12 +1,7 @@
 //! Collector HTTP request router
 
 use super::state::State;
-use crate::{
-    config::collector::{CollectorConfig, Protocol},
-    message,
-    prelude::*,
-    response,
-};
+use crate::{config, message, prelude::*, response};
 use std::{convert::Infallible, sync::Arc};
 use tokio::sync::Mutex;
 use warp::Filter;
@@ -21,7 +16,7 @@ pub struct Router {
     addr: ([u8; 4], u16),
 
     /// Protocol to listen on
-    protocol: Protocol,
+    protocol: config::collector::listen::Protocol,
 
     /// Collector state
     state: StateCell,
@@ -29,7 +24,7 @@ pub struct Router {
 
 impl Router {
     /// Initialize the router from the config
-    pub fn new(config: &CollectorConfig) -> Result<Router, Error> {
+    pub fn new(config: &config::collector::Config) -> Result<Router, Error> {
         let addr = (config.listen.addr.octets(), config.listen.port);
         let protocol = config.listen.protocol;
         let state = Arc::new(Mutex::new(State::new(&config)?));
@@ -64,7 +59,7 @@ impl Router {
         let routes = network.or(collector);
 
         match protocol {
-            Protocol::Http => warp::serve(routes).run(addr).await,
+            config::collector::listen::Protocol::Http => warp::serve(routes).run(addr).await,
         }
     }
 }

--- a/src/collector/state.rs
+++ b/src/collector/state.rs
@@ -1,12 +1,11 @@
 //! Collector state
 
 use crate::{
-    config::collector::CollectorConfig,
-    message,
+    config, message,
     network::{self, Network},
     prelude::*,
 };
-use std::{collections::BTreeMap as Map, process};
+use std::process;
 
 /// Collector state
 #[derive(Debug)]
@@ -17,7 +16,7 @@ pub struct State {
 
 impl State {
     /// Initialize collector state
-    pub fn new(config: &CollectorConfig) -> Result<Self, Error> {
+    pub fn new(config: &config::collector::Config) -> Result<Self, Error> {
         let mut networks = Map::default();
 
         for network in Network::from_config(&config.networks) {
@@ -25,7 +24,7 @@ impl State {
 
             if networks.insert(network_id.clone(), network).is_some() {
                 // TODO(tarcieri): bubble up this error
-                status_err!("duplicate networks in config: {}", &network_id);
+                status_err!("duplicate network in config: {}", &network_id);
                 process::exit(1);
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,20 @@
 //! `sagan.toml` configuration file
 
+use serde::{Deserialize, Serialize};
+
 pub mod agent;
 pub mod collector;
-
-use self::agent::AgentConfig;
-use self::collector::CollectorConfig;
-use serde::{Deserialize, Serialize};
+pub mod network;
 
 /// `sagan.toml` configuration settings
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SaganConfig {
     /// Monitoring agent configuration
-    pub agent: Option<AgentConfig>,
+    pub agent: Option<agent::Config>,
 
     /// Collector configuration
-    pub collector: Option<CollectorConfig>,
+    pub collector: Option<collector::Config>,
 }
 
 impl SaganConfig {

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -1,14 +1,16 @@
 //! `sagan.toml` monitoring agent configuration settings
 
+pub use tendermint::config::TendermintConfig;
+
 use crate::error::{Error, ErrorKind};
+use iqhttp::Uri;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tendermint::{config::TendermintConfig, net};
 
 /// Tendermint node-related config settings from `sagan.toml`
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct AgentConfig {
+pub struct Config {
     /// Location of monitored Tendermint node's `--home` directory
     pub node_home: PathBuf,
 
@@ -16,7 +18,7 @@ pub struct AgentConfig {
     pub collector: CollectorAddr,
 }
 
-impl AgentConfig {
+impl Config {
     /// Path to the node's configuration directory
     pub fn config_dir(&self) -> PathBuf {
         self.node_home.join("config")
@@ -47,6 +49,7 @@ pub enum CollectorAddr {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HttpConfig {
-    /// Address of collector http service
-    pub addr: net::Address,
+    /// Address of collector HTTP service
+    #[serde(with = "iqhttp::serializers::uri")]
+    pub uri: Uri,
 }

--- a/src/config/collector.rs
+++ b/src/config/collector.rs
@@ -1,66 +1,18 @@
 //! `sagan.toml` Collector configuration settings
 
 use serde::{Deserialize, Serialize};
-use std::net::Ipv4Addr;
 
-/// Default port number (Sagan's number: 7E22)
-pub const DEFAULT_PORT: u16 = 7322;
+use crate::config::network;
+
+pub mod listen;
 
 /// Collector config settings from `sagan.toml`
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CollectorConfig {
+pub struct Config {
     /// Listen configuration
-    pub listen: ListenConfig,
+    pub listen: listen::Config,
 
     /// Networks this collector is collecting information about
-    pub networks: NetworkConfig,
-}
-
-/// Listen config: controls where the collector listens for connections
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ListenConfig {
-    /// IPv4 address to listen on
-    // TODO(tarcieri): IPv6
-    pub addr: Ipv4Addr,
-
-    /// Port to listen on
-    pub port: u16,
-
-    /// Protocol to listen on
-    pub protocol: Protocol,
-}
-
-impl Default for ListenConfig {
-    fn default() -> Self {
-        Self {
-            addr: Ipv4Addr::new(127, 0, 0, 1),
-            port: DEFAULT_PORT,
-            protocol: Protocol::default(),
-        }
-    }
-}
-
-/// Protocol to listen on
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-pub enum Protocol {
-    /// Plaintext HTTP
-    // TODO(tarcieri): HTTPS, gRPC
-    #[serde(rename = "http")]
-    Http,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Protocol::Http
-    }
-}
-
-/// Types of networks this collector is collecting information about
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct NetworkConfig {
-    /// Tendermint networks
-    #[serde(default)]
-    pub tendermint: Vec<tendermint::chain::Id>,
+    pub networks: network::Config,
 }

--- a/src/config/collector/listen.rs
+++ b/src/config/collector/listen.rs
@@ -1,0 +1,47 @@
+//! Listen config.
+
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+
+/// Default port number (Sagan's number: 7E22)
+pub const DEFAULT_PORT: u16 = 7322;
+
+/// Listen config: controls where the collector listens for connections
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// IPv4 address to listen on
+    // TODO(tarcieri): IPv6
+    pub addr: Ipv4Addr,
+
+    /// Port to listen on
+    pub port: u16,
+
+    /// Protocol to listen on
+    pub protocol: Protocol,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            addr: Ipv4Addr::new(127, 0, 0, 1),
+            port: DEFAULT_PORT,
+            protocol: Protocol::default(),
+        }
+    }
+}
+
+/// Protocol to listen on
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum Protocol {
+    /// Plaintext HTTP
+    // TODO(tarcieri): HTTPS, gRPC
+    #[serde(rename = "http")]
+    Http,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Protocol::Http
+    }
+}

--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -1,0 +1,13 @@
+//! Network configuration.
+
+pub mod tendermint;
+
+use serde::{Deserialize, Serialize};
+
+/// Types of network this collector is collecting information about
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    /// Tendermint network
+    #[serde(default)]
+    pub tendermint: Vec<tendermint::Config>,
+}

--- a/src/config/network/tendermint.rs
+++ b/src/config/network/tendermint.rs
@@ -1,0 +1,29 @@
+//! Tendermint network configuration.
+
+use serde::{Deserialize, Serialize};
+use tendermint::chain;
+
+/// Tendermint network configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Chain ID.
+    pub chain_id: chain::Id,
+
+    /// Validator operator address.
+    // TODO(tarcieri): proper address type
+    pub validator_addr: Option<String>,
+
+    /// Mintscan API endpoint.
+    #[cfg(feature = "mintscan")]
+    pub mintscan: Option<MintscanConfig>,
+}
+
+/// Mintscan configuration.
+#[cfg(feature = "mintscan")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MintscanConfig {
+    /// API host (e.g. `api.cosmostation.io`)
+    pub host: String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Sagan: observability tool for Cosmos and other Tendermint applications.
 
-#![deny(missing_docs, trivial_casts, unused_qualifications, rust_2018_idioms)]
 #![forbid(unsafe_code)]
+#![warn(missing_docs, trivial_casts, unused_qualifications, rust_2018_idioms)]
 
 #[macro_use]
 extern crate abscissa_core;

--- a/src/monitor/net_info.rs
+++ b/src/monitor/net_info.rs
@@ -1,14 +1,13 @@
 //! Network information monitor
 
 use super::message::Message;
-use crate::error::{Error, ErrorKind};
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use tendermint::{net, node};
 use tendermint_rpc::{Client, HttpClient};
 
 /// Map of peer IDs to their peer information
-type PeerMap = BTreeMap<node::Id, Peer>;
+type PeerMap = Map<node::Id, Peer>;
 
 /// Network information monitor: monitors the `/net_info` endpoint.
 #[derive(Clone, Debug)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -4,24 +4,24 @@ mod id;
 pub mod tendermint;
 
 pub use self::id::Id;
-use crate::{config::collector::NetworkConfig, message};
+use crate::{config, message};
 use serde::Serialize;
 
 /// Types of networks
 #[derive(Debug)]
 pub enum Network {
-    /// Tendermint networks
+    /// Tendermint network
     Tendermint(Box<self::tendermint::Network>),
 }
 
 impl Network {
-    /// Initialize networks from the given configuration
-    pub fn from_config(config: &NetworkConfig) -> Vec<Network> {
+    /// Initialize network from the given configuration
+    pub fn from_config(config: &config::network::Config) -> Vec<Network> {
         let mut networks = vec![];
 
-        for id in &config.tendermint {
+        for tm_config in &config.tendermint {
             networks.push(Network::Tendermint(Box::new(
-                self::tendermint::Network::new(id.clone()),
+                self::tendermint::Network::new(tm_config.chain_id.clone()),
             )))
         }
 

--- a/src/network/tendermint.rs
+++ b/src/network/tendermint.rs
@@ -7,9 +7,8 @@ use crate::{
     prelude::*,
 };
 use serde::Serialize;
-use std::collections::BTreeMap as Map;
 
-/// Tendermint networks
+/// Tendermint network
 #[derive(Debug)]
 pub struct Network {
     /// Chain ID for this network
@@ -104,7 +103,7 @@ impl Network {
     }
 }
 
-/// Nodes in Tendermint networks
+/// Nodes in Tendermint network
 #[derive(Clone, Debug, Serialize)]
 pub struct Node {
     /// Node ID

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,15 @@
 //! Application-local prelude: conveniently import types/functions/macros
 //! which are generally useful and should be available everywhere.
 
-/// Abscissa core prelude
+/// Abscissa core prelude.
 pub use abscissa_core::prelude::*;
 
-/// Application-level types
-pub use crate::{application::APP, config::SaganConfig, error::Error};
+/// Application-level types.
+pub use crate::{
+    application::APP,
+    config::SaganConfig,
+    error::{Error, ErrorKind},
+};
+
+/// Map type.
+pub use std::collections::BTreeMap as Map;


### PR DESCRIPTION
Initial support for using Mintscan for black box monitoring, providing a source for chain state and validator uptime that isn't our own infrastructure.

Adds a "poller" subsystem to the collector for data sources that are polled instead of pushed.

Refactors configuration to support additional information about Tendermint networks, including a Mintscan API endpoint and the validator's operator address.

Adds an initial Mintscan poller which checks the chain status endpoint and, if the validator address is configured, the validator uptime endpoint for the configured address.

If the validator's last signed height exceeds a certain threshold away from the chain tip, it presently emits an `error!` log event.

The longer term goal is to use the `datadog` crate to page us when this happens, but that work is deliberately left to a followup PR.