### PR TITLE
Report events from `Poller` to `Collector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "iqhttp"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3de50f560e3ddb9abfaa1f56bd39f7941959ee93976b360b43fb5fe7293bfd3"
+checksum = "9c4b71df16fba3f07427fb932a494f490fac4d59f8d9eeb0801ea0ece6c952f0"
 dependencies = [
  "hyper",
  "hyper-rustls",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "mintscan"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d340d9e91e50e25794e25b0c38942a29403ced412c96123ec0ec680593e5824"
+checksum = "9a362b5df34b752e8139e3e669ac1856cbce772f289b75b30961c23905161fb5"
 dependencies = [
  "iqhttp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ abscissa_tokio = "0.6.0-pre.1"
 futures = "0.3"
 gumdrop = "0.7"
 home = "0.5"
-iqhttp = { version = "0.0.1", features = ["serde"] }
+iqhttp = { version = "0.1", features = ["serde"] }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1" }
 tendermint = "0.19"
@@ -34,7 +34,7 @@ tokio = "1"
 warp = "0.3"
 
 # optional dependencies
-mintscan = { version = "0.0.1", optional = true }
+mintscan = { version = "0.1", optional = true }
 
 [dev-dependencies]
 once_cell = "1"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -73,6 +73,14 @@ impl Collector {
             }
         }
     }
+
+    /// Handle incoming poller info
+    fn poller_info(&self, info: request::PollEvent) -> Result<Response, Error> {
+        info!("got {:?}", info);
+
+        // TODO(tarcieri): real response
+        Ok(Response::Message)
+    }
 }
 
 impl Service<Request> for Collector {
@@ -88,6 +96,7 @@ impl Service<Request> for Collector {
         let result = match req {
             Request::Message(msg) => self.handle_message(msg),
             Request::NetworkState(id) => self.network_state(&id),
+            Request::PollEvent(info) => self.poller_info(info),
         };
 
         Box::pin(async { result })

--- a/src/collector/request.rs
+++ b/src/collector/request.rs
@@ -2,6 +2,9 @@
 
 use crate::{message, network};
 
+/// Block height type
+pub type BlockHeight = u64;
+
 /// Requests to the collector.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Request {
@@ -10,10 +13,36 @@ pub enum Request {
 
     /// Get the network state for a given network.
     NetworkState(network::Id),
+
+    /// Report information obtained from an external poller.
+    PollEvent(PollEvent),
 }
 
 impl From<message::Envelope> for Request {
     fn from(msg: message::Envelope) -> Request {
         Request::Message(msg)
     }
+}
+
+impl From<PollEvent> for Request {
+    fn from(info: PollEvent) -> Request {
+        Request::PollEvent(info)
+    }
+}
+
+/// Information obtained from an external poller.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PollEvent {
+    /// Source the data was obtained from
+    // TODO(tarcieri): better type for this?
+    pub source: &'static str,
+
+    /// Network ID the information is associated with.
+    pub network_id: network::Id,
+
+    /// Current block height.
+    pub current_height: BlockHeight,
+
+    /// Last block signed by the validator for this chain, if known.
+    pub last_signed_height: Option<BlockHeight>,
 }

--- a/src/collector/router.rs
+++ b/src/collector/router.rs
@@ -68,7 +68,7 @@ where
     let result = service
         .ready()
         .await
-        .expect("service not ready")
+        .expect("collector not ready") // TODO(tarcieri): better error handling
         .call(Request::NetworkState(network_id.into()))
         .await
         .map(|resp| match resp {
@@ -87,13 +87,12 @@ pub async fn collector_post<S>(
     mut service: S,
 ) -> Result<impl warp::Reply, Infallible>
 where
-    S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + Clone + 'static,
-    S::Future: Send,
+    S: Service<Request, Response = Response, Error = BoxError> + Sync + Clone + 'static,
 {
     let result = service
         .ready()
         .await
-        .expect("service not ready")
+        .expect("collector not ready") // TODO(tarcieri): better error handling
         .call(msg.into())
         .await;
 

--- a/src/network/id.rs
+++ b/src/network/id.rs
@@ -20,6 +20,12 @@ impl Display for Id {
 
 impl From<tendermint::chain::Id> for Id {
     fn from(chain_id: tendermint::chain::Id) -> Id {
+        Id::from(&chain_id)
+    }
+}
+
+impl From<&tendermint::chain::Id> for Id {
+    fn from(chain_id: &tendermint::chain::Id) -> Id {
         Id(chain_id.as_str().to_owned())
     }
 }


### PR DESCRIPTION
Has the `mintscan::Poller` report data it collects to the `Collector` service in the form of `Request::PollInfo` messages.

This code is a bit handwavy as we're feeling out the requirements as we go, and doesn't yet persist the reported events in any way, but it does log them and provide a path towards keeping the business logic around things like alerting in the `Collector` rather than the individual pollers.